### PR TITLE
Auto detect JAVA_HOME.

### DIFF
--- a/src/ffaudio/Makefile
+++ b/src/ffaudio/Makefile
@@ -1,7 +1,7 @@
 CC := gcc
 LD := $(CC)
 
-JAVA_HOME ?= /usr/lib/jvm/java
+JAVA_HOME=$(shell readlink -f /usr/bin/javac | sed "s:bin/javac::")
 
 CFLAGS := -O2 -fPIC
 LDLIBS := -shared -Wl,-soname,libffaudio.so -lavformat -lavcodec -lswresample

--- a/src/m3g/Makefile
+++ b/src/m3g/Makefile
@@ -2,7 +2,7 @@ CC := gcc
 CXX := g++
 LD := $(CXX)
 
-JAVA_HOME ?= /usr/lib/jvm/java
+JAVA_HOME=$(shell readlink -f /usr/bin/javac | sed "s:bin/javac::")
 
 CFLAGS := -O2 -DM3G_TARGET_LINUX -DM3G_GL_ES_1_1  -fPIC
 CXXFLAGS := $(CFLAGS)

--- a/src/micro3d/Makefile
+++ b/src/micro3d/Makefile
@@ -2,7 +2,7 @@ CC := gcc
 CXX := g++
 LD := $(CXX)
 
-JAVA_HOME ?= /usr/lib/jvm/java
+JAVA_HOME=$(shell readlink -f /usr/bin/javac | sed "s:bin/javac::")
 
 CFLAGS := -ggdb -DM3G_TARGET_LINUX -fPIC -Wall
 CXXFLAGS := $(CFLAGS)


### PR DESCRIPTION
On Ubuntu 22.04, amd64, openjdk 17, this couldn't find `jni.h`, this patch tries to find JAVA_HOME automatically, and I can compile and run this successfully.